### PR TITLE
Added reconnectInterval and changed polling to allow values > 599 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Following options can be set for the **WorxLandroid Mower**:
 | Property  | Description |
 |-----------|-----------|
 | refreshStatusInterval | Interval for refreshing mower status (ONLINE/OFFLINE) and channel 'common#online' in seconds (min="30")|
-| pollingInterval | Interval for polling in seconds (min="30" max="599", after 10 minutes / 600 seconds of inactivity, the connection is closed). |
+| pollingInterval | Interval for polling in seconds (min="30" max="7200"). |
+| reconnectInterval | Interval for reconnecting to AWS in seconds (min="30" max="599", after 10 minutes / 600 seconds of inactivity, the connection is closed). |
 
 ## Properties
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.openhab.addons.bundles</groupId>
     <artifactId>org.openhab.addons.reactor.bundles</artifactId>
-    <version>3.4.1</version>
+    <version>3.4.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.openhab.binding.worxlandroid</artifactId>

--- a/src/main/history/dependencies.xml
+++ b/src/main/history/dependencies.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.binding.worxlandroid-3.4.1">
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" name="org.openhab.binding.worxlandroid-3.4.3-SNAPSHOT">
     <feature version="0.0.0">
         <feature>openhab-runtime-base</feature>
         <feature>wrap</feature>
         <bundle>mvn:com.fasterxml.jackson.core/jackson-core/2.12.0</bundle>
         <bundle>mvn:com.google.code.gson/gson/2.10.1</bundle>
-        <bundle>mvn:org.openhab.addons.bundles/org.openhab.binding.worxlandroid/3.4.1</bundle>
+        <bundle>mvn:org.openhab.addons.bundles/org.openhab.binding.worxlandroid/3.4.3-SNAPSHOT</bundle>
         <bundle>wrap:mvn:org.lastnpe.eea/eea-all/2.2.1</bundle>
         <bundle>wrap:mvn:software.amazon.awssdk.crt/aws-crt/0.21.7</bundle>
         <bundle>wrap:mvn:software.amazon.awssdk.iotdevicesdk/aws-iot-device-sdk/1.11.5</bundle>

--- a/src/main/java/org/openhab/binding/worxlandroid/internal/WorxLandroidMowerHandler.java
+++ b/src/main/java/org/openhab/binding/worxlandroid/internal/WorxLandroidMowerHandler.java
@@ -397,7 +397,8 @@ public class WorxLandroidMowerHandler extends BaseThingHandler implements AWSMes
         pollingJob = scheduler.scheduleWithFixedDelay(pollingRunnable, 60, config.getPollingInterval(),
                 TimeUnit.SECONDS);
 
-        reconnectJob = scheduler.scheduleWithFixedDelay(reconnectRunnable, 60, config.getReconnectInterval(), TimeUnit.SECONDS);
+        reconnectJob = scheduler.scheduleWithFixedDelay(reconnectRunnable, 60, config.getReconnectInterval(),
+                TimeUnit.SECONDS);
     }
 
     /**

--- a/src/main/java/org/openhab/binding/worxlandroid/internal/WorxLandroidMowerHandler.java
+++ b/src/main/java/org/openhab/binding/worxlandroid/internal/WorxLandroidMowerHandler.java
@@ -85,6 +85,7 @@ public class WorxLandroidMowerHandler extends BaseThingHandler implements AWSMes
 
     private @Nullable ScheduledFuture<?> refreshStatusJob;
     private @Nullable ScheduledFuture<?> pollingJob;
+    private @Nullable ScheduledFuture<?> reconnectJob;
 
     private boolean restoreZoneMeter = false;
     private int[] zoneMeterRestoreValues = {};
@@ -154,6 +155,21 @@ public class WorxLandroidMowerHandler extends BaseThingHandler implements AWSMes
                 }
             } catch (AWSException e) {
                 logger.error("PollingRunnable {}: {}", e.getLocalizedMessage(), mower.getSerialNumber());
+            }
+        }
+    };
+
+    /**
+     * Defines a runnable for a polling job.
+     * Polls AWS mqtt.
+     */
+    private Runnable reconnectRunnable = new Runnable() {
+        @Override
+        public void run() {
+            WorxLandroidBridgeHandler bridgeHandler = getWorxLandroidBridgeHandler();
+            if (bridgeHandler != null) {
+                logger.info("reconnecting");
+                bridgeHandler.reconnectToWorx();
             }
         }
     };
@@ -380,6 +396,8 @@ public class WorxLandroidMowerHandler extends BaseThingHandler implements AWSMes
 
         pollingJob = scheduler.scheduleWithFixedDelay(pollingRunnable, 60, config.getPollingInterval(),
                 TimeUnit.SECONDS);
+
+        reconnectJob = scheduler.scheduleWithFixedDelay(reconnectRunnable, 60, config.getReconnectInterval(), TimeUnit.SECONDS);
     }
 
     /**
@@ -408,6 +426,10 @@ public class WorxLandroidMowerHandler extends BaseThingHandler implements AWSMes
 
         if (pollingJob != null) {
             pollingJob.cancel(true);
+        }
+
+        if (reconnectJob != null) {
+            reconnectJob.cancel(true);
         }
     }
 

--- a/src/main/java/org/openhab/binding/worxlandroid/internal/config/MowerConfiguration.java
+++ b/src/main/java/org/openhab/binding/worxlandroid/internal/config/MowerConfiguration.java
@@ -21,6 +21,7 @@ public class MowerConfiguration {
 
     public int refreshStatusInterval = 60;
     public int pollingInterval = 300;
+    public int reconnectInterval = 300;
 
     public int getRefreshStatusInterval() {
         return refreshStatusInterval;
@@ -38,9 +39,17 @@ public class MowerConfiguration {
         this.pollingInterval = pollingInterval;
     }
 
+    public int getReconnectInterval() {
+        return reconnectInterval;
+    }
+
+    public void setReconnectInterval(int pollingInterval) {
+        this.reconnectInterval = reconnectInterval;
+    }
+
     @Override
     public String toString() {
-        return String.format("MowerConfiguration [pollingInterval='%d', refreshStatusInterval='%d']", pollingInterval,
-                refreshStatusInterval);
+        return String.format("MowerConfiguration [pollingInterval='%d', refreshStatusInterval='%d', reconnectInterval='%d']", pollingInterval,
+                refreshStatusInterval, reconnectInterval);
     }
 }

--- a/src/main/java/org/openhab/binding/worxlandroid/internal/config/MowerConfiguration.java
+++ b/src/main/java/org/openhab/binding/worxlandroid/internal/config/MowerConfiguration.java
@@ -49,7 +49,8 @@ public class MowerConfiguration {
 
     @Override
     public String toString() {
-        return String.format("MowerConfiguration [pollingInterval='%d', refreshStatusInterval='%d', reconnectInterval='%d']", pollingInterval,
-                refreshStatusInterval, reconnectInterval);
+        return String.format(
+                "MowerConfiguration [pollingInterval='%d', refreshStatusInterval='%d', reconnectInterval='%d']",
+                pollingInterval, refreshStatusInterval, reconnectInterval);
     }
 }

--- a/src/main/resources/OH-INF/thing/mower.xml
+++ b/src/main/resources/OH-INF/thing/mower.xml
@@ -88,9 +88,16 @@
 				<required>true</required>
 			</parameter>
 
-			<parameter name="pollingInterval" unit="s" type="integer" min="30" max="599">
+			<parameter name="pollingInterval" unit="s" type="integer" min="30" max="7200">
 				<label>Polling interval</label>
-				<description>Interval for polling in seconds (after 10 minutes / 600 seconds of inactivity, the connection is
+				<description>Interval for polling in seconds</description>
+				<default>599</default>
+				<required>true</required>
+			</parameter>
+
+			<parameter name="reconnectInterval" unit="s" type="integer" min="30" max="599">
+				<label>Reconnect interval</label>
+				<description>Interval for reconnecting in seconds (after 10 minutes / 600 seconds of inactivity, the connection is
 					closed)</description>
 				<default>300</default>
 				<required>true</required>


### PR DESCRIPTION
I played around a bit with the Pluigin and found a working solution.
I replaced the polling every 10 minutes with a reconnect.
Then I also set the polling to 60 minutes.
This way you don't always get some info updates (e.g. when the mower is charging and the charging status changes), but you are not blocked and have full control over the mower all the time.
You get all the updates while mowing.
Status updates (e.g. when the cable is missing) are always received.